### PR TITLE
Update link to documentation framework

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ The tool uses modern python packages like [Click](https://click.palletsprojects.
 
 ## Documentation
 
-We use [mkdocs](https://www.mkdocs.org) with [mkdocs-material](https://squidfunk.github.io/mkdocs-material/) theme. The docs are structured using the [divio documentation system](https://documentation.divio.com/). To view the docs locally:
+We use [mkdocs](https://www.mkdocs.org) with [mkdocs-material](https://squidfunk.github.io/mkdocs-material/) theme. The docs are structured using the [Diátaxis documentation framework](https://diataxis.fr/). To view the docs locally:
 
 ```shell
 pip install mkdocs-material


### PR DESCRIPTION
Hallo @timvink, het nieuwe website voor de "documentation system" is nu diataxis.fr (ik ben de auteur). 

Gebruikt ING de systeem ook in andere software?