### PR TITLE
be lenient when getting the pr id from the 'az boards work-item show'…

### DIFF
--- a/src/doing/pr/create_pr.py
+++ b/src/doing/pr/create_pr.py
@@ -1,4 +1,5 @@
 import os
+import re
 import subprocess
 import sys
 
@@ -62,7 +63,7 @@ def cmd_create_pr(
                 # For example
                 # url = 'vstfs:///Git/PullRequestId/bbd257b1-b8a9-1fc2-b123-1ea2cc23c333%2f4d2e1234-c1d0-1234-1f23-c1234d05d471%2f12345' # noqa
                 # The bit after %2f is the pullrequestid (12345)
-                related_pr_id = relation.get("url").rpartition("%2f")[2]
+                related_pr_id = re.findall('^.*%2[fF]([0-9]+)$', relation.get("url"))[0]
                 related_pr_id_status = run_command(
                     f"az repos pr show --id {related_pr_id} --query 'status' --org '{organization}'"
                 )


### PR DESCRIPTION
I noticed that the response for 'az boards work-item show'x ' sometimes uses `%2f` and sometimes `%2F`.
 
The current code only expects `%2f` and thus fails when Azure replies with `%2F`

This PR makes it lenient i.e. accepts both 
