### PR TITLE
directly check for the .doing-cli.yml file in the root directory of the repo (instead of traversing the directory tree)

### DIFF
--- a/src/doing/utils.py
+++ b/src/doing/utils.py
@@ -96,14 +96,12 @@ def find_dotfile(filename: str) -> str:
     Args:
         filename (str): name of the file.
     """
-    wd = Path(os.getcwd())
+    git_repo_root_dir = shell_output("git rev-parse --show-toplevel")
+    wd = Path(git_repo_root_dir)
 
-    i = 0
-    while i != 15 or wd == Path("/"):
-        filepath = wd / Path(filename)
-        if filepath.is_file():
-            return str(filepath)
-        i += 1
+    filepath = wd / Path(filename)
+    if filepath.is_file():
+        return str(filepath)
 
     return ""
 


### PR DESCRIPTION
I thought noticed that with the latest release (v1.2) the config file was not found anymore (unless I started doing from the root directory of the repo).

This turned out to be a local issue but I wondered why the directory traversal to find the config file was used.

This PR directly retrieves the config file from the root directory of the git repo.
AFAIK this was the requirement but maybe you intentionally build it with the directory traversal to also be able to find the config file in the home directory.

Anyway: I noticed this commit only worked as I had the environment variable `DOING_CONFIG_VERBOSE_SHELL` set.
When this variable is not set then doing wants to determine if the command should be echo-ed by searching for this variable in the config file... I.e. a nice recursion error.. ;)  

So probably you can reject this pull request unless you feel this code nicely meets the requirement and the recursion can be fixed. 