### PR TITLE
add alias for doing pr open

### DIFF
--- a/src/doing/pr/commands.py
+++ b/src/doing/pr/commands.py
@@ -5,6 +5,7 @@ from doing.utils import get_config, run_command, get_repo_name, shell_output
 from doing.options import get_common_options
 from doing.pr.create_pr import cmd_create_pr
 from doing.pr.open_pr import cmd_open_pr
+from doing.open import commands as open_group
 
 console = Console()
 
@@ -15,6 +16,18 @@ def pr():
     Work with pull requests.
     """
     pass
+
+
+@pr.command()
+@click.argument("pullrequest_id", default=-1)
+def open(pullrequest_id):
+    """
+    Alias: `doing open pr`.
+    """
+    open_group.open(args=["pr", f"{pullrequest_id}"])
+
+
+open.__doc__ = str(open.__doc__) + str(open_group.pr.__doc__)
 
 
 @pr.command()


### PR DESCRIPTION
Solves #83 

It's a bit hacky, but there doesn't seem to be an elegant, native solution within Click to do something similar, from what I've seen. 
If I understood correctly, there are examples on how to define aliases of commands from the same group, but I could not find examples of commands from different groups. 

This is based on [this](https://stackoverflow.com/questions/47983367/alias-for-a-chain-of-commands) question.

Unfortunately the docstrings are not exacly the same, with this solution. 
![image](https://user-images.githubusercontent.com/4223965/130788510-433d6587-e9d6-452b-9b58-a4fae7381534.png)
