### PR TITLE
Update CI to run on python 3.9, drop 3.6

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       matrix: 
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.7, 3.8, 3.9]
     steps:
     - uses: actions/checkout@master
     - name: Setup Python  

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -7,11 +7,11 @@ jobs:
     strategy:
       matrix: 
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.6, 3.7, 3.8, 3.9]
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v2
     - name: Setup Python  
-      uses: actions/setup-python@master
+      uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
     - name: Static code checking with pyflakes

--- a/.github/workflows/unittests_with_codecov.yml
+++ b/.github/workflows/unittests_with_codecov.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix: 
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.7, 3.8, 3.9]
     steps:
     - uses: actions/checkout@master
     - name: Setup Python ${{ matrix.python-version }}

--- a/.github/workflows/unittests_with_codecov.yml
+++ b/.github/workflows/unittests_with_codecov.yml
@@ -17,11 +17,11 @@ jobs:
     strategy:
       matrix: 
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.6, 3.7, 3.8, 3.9]
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v2
     - name: Setup Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
     - name: Static code checking with pyflakes


### PR DESCRIPTION
Fixed CI. For the very selfish reason of it looking ugly in my new hobby [project](https://timvink.github.io/project-monitor/) 😆 

![image](https://user-images.githubusercontent.com/5570380/143092960-83305014-257c-4fb9-bc36-de1657ca4ccd.png)
