### PR TITLE
Add option to specify custom states when listing

### DIFF
--- a/docs/config/config_file.md
+++ b/docs/config/config_file.md
@@ -34,6 +34,7 @@ The config can also contain some optional parameters that are not required to be
 | `verbose_shell` | Set to 'true' to print every shell command `doing` runs for you in the background. Meant for debugging and interested developers. Default is 'false'.
 | `user_aliases` | A list of user aliases that you can use when specifying reviewers or assignees. Note that the `@me` alias is always available.
 | `default_reviewers` | The default reviewers assigned when creating pull requests. Space separated list of user emails (case sensitive). Find your own with `az ad signed-in-user show --query 'mail'`.
+| `custom_states` | A dictionary of work item states or lists of states to use when filtering work items with `doing list --state "state"`. |
 | `defaults` | Allows you to overwrite defaults of command options. See explanation below.
 | `merge_strategy` | Azure devops supports pull requests with rebase (see [blogpost](https://devblogs.microsoft.com/devops/pull-requests-with-rebase/#rebase)). Should be one of "basic merge", "squash merge", "rebase and fast-forward", "rebase with merge commit". If specified, it will update the policies on a repository level to only allow that merge strategy.
 | `encoding` | The encoding used to parse the response of terminal commands. This is auto-detected by default but can be set explicitly in case you have encoding trouble.
@@ -49,6 +50,9 @@ user_aliases:
     john: 'John.Doe@company.com'
     jane: 'Jane.Doe@email.net'
 default_reviewers: 'john.doe@domain.com'
+custom_states:
+    removed: Removed
+    resolved: [Resolved, Closed]
 defaults:
     DOING_LIST_STATE: all
 merge_strategy: "rebase and fast-forward"
@@ -99,6 +103,29 @@ default_reviewers: 'email1@domain.com email2@domain.com'
 ```
 
 You can also use the aliases specified in `user_aliases` to specify the `default_reviewers`.
+
+### Setting `custom_states`
+
+When listing work items you can filter them by state with `doing list --state "state"`. `doing-cli` includes some default options for this filter:
+
+- `open`: state not in `['Resolved','Closed','Done','Removed']`
+- `closed`: state in `['Resolved','Closed','Done']`
+- `all`: state different than `'Removed'`
+
+You can overwrite these or specify your own custom state filters. For example:
+
+```yaml
+# .doing-cli-config.yml
+custom_states:
+    removed: Removed
+    resolved: [Resolved, Closed]
+```
+
+Which can be used as:
+
+```bash
+doing list --state "removed"
+```
 
 ### Setting `defaults`
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -58,7 +58,8 @@ $ doing list
 
 - [Getting started](get_started/install.md): A hands-on introduction to `doing` for developers. *Recommended for all new users*
 - [How-to guides](howto/workflow_new_item.md): Step-by-step guides. Covers key tasks and operations and common problems.
-- [Commands](config/config_file.md): Technical reference covering the config file and all commands.
+- [Commands](reference/manual/init/): Technical reference covering the all commands.
+- [Config](config/config_file.md): Technical reference covering configuration using a config file or environment variables.
 - [Discussion](discussion/oneproject_setup.md): Explanation. Clarification and discussion of key topics.
 
 ## `--help`

--- a/src/doing/list/_list.py
+++ b/src/doing/list/_list.py
@@ -53,8 +53,13 @@ def work_item_query(
         elif state.startswith("'") and state.endswith("'"):
             query += f"AND [System.State] = {state} "
         else:
-            # TODO raise error
-            pass
+            raise ValueError(
+                f'Invalid state: "{state}"\n'
+                "State should be:\n"
+                '- one of the doing-cli default states: "open", "closed", "all"\n'
+                "- a custom state defined in .doing-cli-config.yml\n"
+                "- a state available in this team between apostrophes, e.g. \"'Active'\""
+            )
 
     if type:
         validate_work_item_type(type)

--- a/src/doing/list/_list.py
+++ b/src/doing/list/_list.py
@@ -71,7 +71,7 @@ def work_item_query(
             raise ValueError(
                 f'Invalid state: "{state}". State should be:\n'
                 '- one of the doing-cli default states: "open", "closed", "all"\n'
-                "- a custom state defined in .doing-cli-config.yml\n"
+                "- a custom state defined 'custom_states' in the .doing-cli.config.yml file\n"
                 "- a state available in this team, between apostrophes, e.g. \"'Active'\""
             )
 

--- a/src/doing/list/_list.py
+++ b/src/doing/list/_list.py
@@ -51,14 +51,11 @@ def work_item_query(
 
     if state:
         custom_states = get_config("custom_states", {})
-        if custom_states:
-            for custom_state, state_list in custom_states.items():
-                if state == custom_state:
-                    if type(state_list) is not list:
-                        state_list = [state_list]
-                    state_list_string = ",".join([f"'{x}'" for x in state_list])
-                    query += f"AND [System.State] IN ({state_list_string}) "
-                    break
+        if state in custom_states.keys():
+            if type(custom_states[state]) is not list:
+                custom_states[state] = [custom_states[state]]
+            state_list = ",".join([f"'{x}'" for x in custom_states[state]])
+            query += f"AND [System.State] IN ({state_list}) "
         elif state == "open":
             query += "AND [System.State] NOT IN ('Resolved','Closed','Done','Removed') "
         elif state == "closed":
@@ -71,7 +68,7 @@ def work_item_query(
             raise ValueError(
                 f'Invalid state: "{state}". State should be:\n'
                 '- one of the doing-cli default states: "open", "closed", "all"\n'
-                "- a custom state defined 'custom_states' in the .doing-cli.config.yml file\n"
+                "- a custom state defined under 'custom_states' in the .doing-cli.config.yml file\n"
                 "- a state available in this team, between apostrophes, e.g. \"'Active'\""
             )
 

--- a/src/doing/list/_list.py
+++ b/src/doing/list/_list.py
@@ -34,7 +34,7 @@ def work_item_query(
 
     # Get all workitems
     query = "SELECT [System.Id],[System.Title],[System.AssignedTo],"
-    query += "[System.WorkItemType],[System.State],[System.CreatedDate], [System.State]"
+    query += "[System.WorkItemType],[System.State],[System.CreatedDate], [System.State] "
     query += f"FROM WorkItems WHERE [System.AreaPath] = '{area}' "
     # Filter on iteration. Note we use UNDER so that user can choose to provide teams path for all sprints.
     query += f"AND [System.IterationPath] UNDER '{iteration}' "
@@ -75,6 +75,7 @@ def work_item_query(
     if work_item_type:
         validate_work_item_type(work_item_type)
         query += f"AND [System.WorkItemType] = '{work_item_type}' "
+
     if story_points:
         if story_points == "unassigned":
             query += "AND [Microsoft.VSTS.Scheduling.StoryPoints] = '' "

--- a/src/doing/list/_list.py
+++ b/src/doing/list/_list.py
@@ -66,10 +66,10 @@ def work_item_query(
             query += f"AND [System.State] = {state} "
         else:
             raise ValueError(
-                f'Invalid state: "{state}". State should be:\n'
-                '- one of the doing-cli default states: "open", "closed", "all"\n'
+                f"Invalid state: '{state}'. State should be:\n"
+                "- one of the doing-cli default states: 'open', 'closed', 'all'\n"
                 "- a custom state defined under 'custom_states' in the .doing-cli.config.yml file\n"
-                "- a state available in this team, between apostrophes, e.g. \"'Active'\""
+                "- a state available in this team, between quotes, e.g. \"'Active'\""
             )
 
     if work_item_type:

--- a/src/doing/list/_list.py
+++ b/src/doing/list/_list.py
@@ -44,6 +44,8 @@ def work_item_query(
 
     if state:
         # TODO allow other custom states from config
+        # load list of states from config
+        # if there are states defined there, use them, otherwise use defaults:
         if state == "open":
             query += "AND [System.State] NOT IN ('Resolved','Closed','Done','Removed') "
         elif state == "closed":
@@ -54,11 +56,10 @@ def work_item_query(
             query += f"AND [System.State] = {state} "
         else:
             raise ValueError(
-                f'Invalid state: "{state}"\n'
-                "State should be:\n"
+                f'Invalid state: "{state}". State should be:\n'
                 '- one of the doing-cli default states: "open", "closed", "all"\n'
                 "- a custom state defined in .doing-cli-config.yml\n"
-                "- a state available in this team between apostrophes, e.g. \"'Active'\""
+                "- a state available in this team, between apostrophes, e.g. \"'Active'\""
             )
 
     if type:

--- a/src/doing/list/commands.py
+++ b/src/doing/list/commands.py
@@ -42,7 +42,7 @@ from doing.utils import get_config
     type=str,
     help=(
         'Filter by state. State should be: one of the doing-cli default states: "open", "closed", "all"; '
-        "a custom state defined 'custom_states' in the .doing-cli.config.yml file; "
+        "a custom state defined under 'custom_states' in the .doing-cli.config.yml file; "
         "or a state available in this team, between apostrophes, e.g. \"'Active'\". "
         'Defaults to "open"'
     ),

--- a/src/doing/list/commands.py
+++ b/src/doing/list/commands.py
@@ -42,7 +42,7 @@ from doing.utils import get_config
     type=str,
     help=(
         'Filter by state. State should be: one of the doing-cli default states: "open", "closed", "all"; '
-        "a custom state defined in .doing-cli-config.yml; "
+        "a custom state defined 'custom_states' in the .doing-cli.config.yml file; "
         "or a state available in this team, between apostrophes, e.g. \"'Active'\". "
         'Defaults to "open"'
     ),

--- a/src/doing/list/commands.py
+++ b/src/doing/list/commands.py
@@ -99,7 +99,7 @@ def list(assignee, author, label, state, type, web, story_points, output_format)
             state=state,
             area=area,
             iteration=iteration,
-            type=type,
+            work_item_type=type,
             story_points=story_points,
         )
         click.launch(f"{organization}/{project}/_workitems/?_a=query&wiql={quote(query)}")
@@ -109,7 +109,7 @@ def list(assignee, author, label, state, type, web, story_points, output_format)
             author,
             label,
             state,
-            type=type,
+            work_item_type=type,
             story_points=story_points,
             output_format=output_format,
             **get_common_options(),

--- a/src/doing/list/commands.py
+++ b/src/doing/list/commands.py
@@ -41,10 +41,10 @@ from doing.utils import get_config
     default="open",
     type=str,
     help=(
-        'Filter by state. State should be: one of the doing-cli default states: "open", "closed", "all"; '
+        "Filter by state. State should be: one of the doing-cli default states: 'open', 'closed', 'all'; "
         "a custom state defined under 'custom_states' in the .doing-cli.config.yml file; "
-        "or a state available in this team, between apostrophes, e.g. \"'Active'\". "
-        'Defaults to "open"'
+        "or a state available in this team, between quotes, e.g. \"'Active'\". "
+        "Defaults to 'open'."
     ),
     show_envvar=True,
 )
@@ -71,7 +71,10 @@ from doing.utils import get_config
     required=False,
     default="",
     type=str,
-    help="Filter on number of story points. Use 'unassigned' to find empty. You can use the following inequality symbols as prefixes: '>', '>=', '<' and '<='.",  # noqa
+    help=(
+        "Filter on number of story points. Use 'unassigned' to find empty. "
+        "You can use the following inequality symbols as prefixes: '>', '>=', '<' and '<='."
+    ),
     show_envvar=True,
 )
 @click.option(

--- a/src/doing/list/commands.py
+++ b/src/doing/list/commands.py
@@ -1,8 +1,8 @@
-import click
 from urllib.parse import quote
 
-from doing.options import get_common_options
+import click
 from doing.list._list import cmd_list, work_item_query
+from doing.options import get_common_options
 from doing.utils import get_config
 
 
@@ -39,7 +39,8 @@ from doing.utils import get_config
     "-s",
     required=False,
     default="open",
-    type=click.Choice(["open", "closed", "all"]),
+    type=str,
+    # TODO improve docs.
     help="Filter by state. Defaults to 'open'",
     show_envvar=True,
 )

--- a/src/doing/list/commands.py
+++ b/src/doing/list/commands.py
@@ -40,8 +40,12 @@ from doing.utils import get_config
     required=False,
     default="open",
     type=str,
-    # TODO improve docs.
-    help="Filter by state. Defaults to 'open'",
+    help=(
+        'Filter by state. State should be: one of the doing-cli default states: "open", "closed", "all"; '
+        "a custom state defined in .doing-cli-config.yml; "
+        "or a state available in this team, between apostrophes, e.g. \"'Active'\". "
+        'Defaults to "open"'
+    ),
     show_envvar=True,
 )
 @click.option(


### PR DESCRIPTION
Closes most of what's proposed in #94 

- user can create custom state aliases in .doing-cli-config.yml
- user can pass a state directly to `doing list --state`
- fix some wrong links in docs