### PR TITLE
Re-add ``mypy`` and add basic typing

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,3 +35,18 @@ repos:
 # D100 requires all Python files (modules) to have a "public" docstring even if all functions within have a docstring.
 # D104 requires __init__ files to have a docstring
 # W503 line break before binary operator (for compatibility with black)
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v0.961
+    hooks:
+      - id: mypy
+        name: mypy
+        entry: mypy
+        language: python
+        types: [python]
+        args:
+          [
+            --namespace-packages,
+            --show-error-codes,
+            --pretty,
+          ]
+        additional_dependencies: ["types-PyYAML", "types-click", "types-psutil", "pytest", "pytest-mock", "rich"]

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,5 @@
+[mypy-setuptools]
+ignore_missing_imports = True
+
+[mypy-timeago]
+ignore_missing_imports = True

--- a/setup.py
+++ b/setup.py
@@ -4,14 +4,14 @@ import os.path
 from setuptools import find_packages, setup
 
 
-def read(rel_path):
+def read(rel_path: str) -> str:
     """Read a file."""
     here = os.path.abspath(os.path.dirname(__file__))
     with codecs.open(os.path.join(here, rel_path), "r") as fp:
         return fp.read()
 
 
-def get_version(rel_path):
+def get_version(rel_path: str) -> str:
     """Read version from a file."""
     for line in read(rel_path).splitlines():
         if line.startswith("__version__"):
@@ -26,7 +26,13 @@ LONG_DESCRIPTION = file.read()
 file.close()
 
 
-base_packages = ["Click>=8.0.1", "rich>=10.3.0", "pyyaml>=5.4.1", "timeago>=1.0.15", "psutil>=5.8.0"]
+base_packages = [
+    "Click>=8.0.1",
+    "rich>=10.3.0",
+    "pyyaml>=5.4.1",
+    "timeago>=1.0.15",
+    "psutil>=5.8.0",
+]
 dev = [
     "mkdocs-material>=7.1",
     "mkdocs-macros-plugin",

--- a/src/doing/cli.py
+++ b/src/doing/cli.py
@@ -43,7 +43,7 @@ class OrderedGroup(click.Group):
     cls=OrderedGroup,
 )
 @click.version_option(__version__, prog_name="doing-cli")
-def cli():
+def cli() -> None:
     """
     CLI for repository/issue workflow on Azure Devops.
     """

--- a/src/doing/exceptions.py
+++ b/src/doing/exceptions.py
@@ -8,7 +8,7 @@ class ConfigurationError(Exception):
     Raise ConfigurationError.
     """
 
-    def __init__(self, message):
+    def __init__(self, message: str) -> None:
         """
         Set message.
         """
@@ -20,7 +20,7 @@ class InputError(Exception):
     Raise InputError.
     """
 
-    def __init__(self, message):
+    def __init__(self, message: str) -> None:
         """
         Set message.
         """

--- a/src/doing/issue/commands.py
+++ b/src/doing/issue/commands.py
@@ -11,7 +11,7 @@ console = Console()
 
 
 @click.group()
-def issue():
+def issue() -> None:
     """Work with issues."""
     pass
 
@@ -21,7 +21,7 @@ issue.add_command(list)
 
 @issue.command()
 @click.argument("work_item_id", nargs=-1, required=True)
-def close(work_item_id):
+def close(work_item_id) -> None:
     """Close a specific WORK_ITEM_ID.
 
     A '#' prefix is allowed. You can specify multiple IDs by separating with a space.

--- a/src/doing/open/commands.py
+++ b/src/doing/open/commands.py
@@ -123,7 +123,14 @@ def issues():
     organization = get_config("organization")
 
     query = work_item_query(
-        assignee="", author="", label="", state="open", area=area, iteration=iteration, type="", story_points=""
+        assignee="",
+        author="",
+        label="",
+        state="open",
+        area=area,
+        iteration=iteration,
+        work_item_type="",
+        story_points="",
     )
 
     # More on hyperlink query syntax:

--- a/src/doing/open/commands.py
+++ b/src/doing/open/commands.py
@@ -14,7 +14,7 @@ console = Console()
 
 
 @click.group()
-def open():
+def open() -> None:
     """
     Quickly open certain links.
     """
@@ -22,7 +22,7 @@ def open():
 
 
 @open.command()
-def board():
+def board() -> None:
     """
     Open board view.
     """
@@ -43,7 +43,7 @@ def board():
 
 
 @open.command()
-def sprint():
+def sprint() -> None:
     """
     Open current sprint view.
     """
@@ -59,7 +59,7 @@ def sprint():
 
 
 @open.command()
-def repo():
+def repo() -> None:
     """
     Open repository view.
     """
@@ -69,7 +69,7 @@ def repo():
 
 
 @open.command()
-def prs():
+def prs() -> None:
     """
     Open active PRs for repository view.
     """
@@ -79,7 +79,7 @@ def prs():
 
 
 @open.command()
-def pipe():
+def pipe() -> None:
     """
     Open latest pipeline runs for repository view.
     """
@@ -99,7 +99,7 @@ def pipe():
 
 @open.command()
 @click.argument("work_item_id", default=-1)
-def issue(work_item_id):
+def issue(work_item_id) -> None:
     """
     Open a specific WORK_ITEM_ID.
 
@@ -113,7 +113,7 @@ def issue(work_item_id):
 
 
 @open.command()
-def issues():
+def issues() -> None:
     """
     Open all active issues view. Alternatively, use `doing list --web`.
     """
@@ -140,7 +140,7 @@ def issues():
 
 @open.command()
 @click.argument("pullrequest_id", default=-1)
-def pr(pullrequest_id):
+def pr(pullrequest_id) -> None:
     """
     Open a specific PULLREQUEST_ID.
 
@@ -155,7 +155,7 @@ def pr(pullrequest_id):
 
 @open.command()
 @click.argument("branch_name")
-def branch(branch_name):
+def branch(branch_name) -> None:
     """
     Open a specific BRANCH_NAME.
     """
@@ -166,7 +166,7 @@ def branch(branch_name):
 
 
 @open.command()
-def branches():
+def branches() -> None:
     """
     Open an overview of the repositories' branches.
     """
@@ -178,7 +178,7 @@ def branches():
 
 
 @open.command()
-def policies():
+def policies() -> None:
     """
     Open repository policy settings.
 

--- a/src/doing/pr/commands.py
+++ b/src/doing/pr/commands.py
@@ -12,7 +12,7 @@ console = Console()
 
 
 @click.group()
-def pr():
+def pr() -> None:
     """
     Work with pull requests.
     """

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,7 +1,7 @@
 from doing.init._init import parse_reference
 
 
-def test_parse_reference():
+def test_parse_reference() -> None:
     """
     Test extracting info from a work item url.
     """

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,8 +1,10 @@
 import os
 from contextlib import contextmanager
+from pathlib import Path
 
 import pytest
 import yaml
+from pytest_mock.plugin import MockerFixture
 
 from doing.utils import (
     get_az_devop_user_email,
@@ -39,7 +41,7 @@ def working_directory(path):
         os.chdir(prev_cwd)
 
 
-def test_to_snake_case():
+def test_to_snake_case() -> None:
     """
     Test to_snake_case works.
     """
@@ -50,7 +52,7 @@ def test_to_snake_case():
     assert to_snake_case("! weird @ chars #") == "!_weird_@_chars_#"
 
 
-def test_remove_special_chars():
+def test_remove_special_chars() -> None:
     """
     Test remove_special_chars.
     """
@@ -61,7 +63,7 @@ def test_remove_special_chars():
     assert remove_special_chars("my-project") == "myproject"
 
 
-def test_creating_branchnames():
+def test_creating_branchnames() -> None:
     """
     Combines testing remove_special_chars and to_snake_case.
     """
@@ -69,7 +71,7 @@ def test_creating_branchnames():
     assert to_snake_case(remove_special_chars("! # issue %")) == "issue"
 
 
-def test_get_config_key():
+def test_get_config_key() -> None:
     """
     Test overrides via env vars.
     """
@@ -77,7 +79,7 @@ def test_get_config_key():
     assert get_config("team") == "my team"
 
 
-def test_get_config_fallback():
+def test_get_config_fallback() -> None:
     """
     Test overrides via env vars.
     """
@@ -87,7 +89,7 @@ def test_get_config_fallback():
     assert get_config("team1", "foobar") == "foobar"
 
 
-def test_replace_user_aliases(tmp_path):
+def test_replace_user_aliases(tmp_path: Path) -> None:
     """
     Test replacing user aliases.
     """
@@ -121,7 +123,7 @@ def test_replace_user_aliases(tmp_path):
 
 
 @pytest.mark.skip(reason="Only works when logged into az, not on CI builds")
-def test_me_alias():
+def test_me_alias() -> None:
     """
     Only runs in env where you can get user alias.
     """
@@ -130,7 +132,7 @@ def test_me_alias():
     assert replace_user_aliases(text) == get_az_devop_user_email()
 
 
-def test_create_file(tmp_path):
+def test_create_file(tmp_path: Path) -> None:
     """
     Test reading a config file.
     """
@@ -143,16 +145,21 @@ def test_create_file(tmp_path):
         assert get_config("user_aliases") == config["user_aliases"]
 
 
-def test_get_current_work_item_id_works_on_valid_branch(mocker):
+def test_get_current_work_item_id_works_on_valid_branch(mocker: MockerFixture):
     """
     Test the correct workitem ID is returned if present at the start of a branch name.
     """
-    mock_run = mocker.patch("doing.utils.shell_output", return_value="123456_Branch_with_leading_workitem_id")
+    mock_run = mocker.patch(
+        "doing.utils.shell_output",
+        return_value="123456_Branch_with_leading_workitem_id",
+    )
     assert get_current_work_item_id() == "123456"
     mock_run.assert_called_with("git branch --show-current")
 
 
-def test_get_current_work_item_id_fails_on_branch_without_workitem(mocker):
+def test_get_current_work_item_id_fails_on_branch_without_workitem(
+    mocker: MockerFixture,
+) -> None:
     """
     Test exception handling on a branch name without a workitem ID.
     """


### PR DESCRIPTION
The second commit shows a bug in the current code found by adding typing in the third commit. The keyword argument has the wrong name there.

Running ``mypy`` in ``--strict`` mode returns about 75 warnings, which should be doable to resolve as well.

Some changes to the formatting are compatible with the current setup of `black`. Let me know if you want to revert them, but line length of some lines was really quite long.