### PR TITLE
Branch prefix option

### DIFF
--- a/docs/reference/manual/pr_create.md
+++ b/docs/reference/manual/pr_create.md
@@ -16,6 +16,7 @@ doing pr create 1234 --draft -r "@me jane.doe@company.com"
 doing pr create 1234 --draft --checkout
 doing pr create 1234 --delete-source-branch --self-approve --auto-complete
 doing pr create 1234 --default-branch develop
+doing pr create 1234 --branch-prefix "fix/"
 ```
 
 !!! notes ""

--- a/docs/reference/manual/workon.md
+++ b/docs/reference/manual/workon.md
@@ -17,6 +17,7 @@ doing workon "an issue" --reviewers "john.doe@company.com jane.doe@company.com"
 doing workon "an issue" --no-auto-complete --no-draft --self-approve
 doing workon "an issue" --story-points 3
 doing workon "an issue" --default-branch develop
+doing workon "an issue" --branch-prefix "fix/"
 ```
 
 ## Options

--- a/src/doing/pr/commands.py
+++ b/src/doing/pr/commands.py
@@ -115,6 +115,14 @@ def close(pr_id):
     help="The name of the branch to branch from and to. It overrides the repository's default branch.",
     show_envvar=True,
 )
+@click.option(
+    "--branch-prefix",
+    required=False,
+    default="",
+    type=str,
+    help="The prefix to be prepended to the branch name. Defaults to \"\"",
+    show_envvar=True,
+)
 def create(
     work_item_id: str,
     draft: bool,
@@ -124,6 +132,7 @@ def create(
     checkout: bool,
     delete_source_branch: bool,
     default_branch,
+    branch_prefix: str,
     web: bool,
 ) -> None:
     """
@@ -140,6 +149,7 @@ def create(
         checkout,
         delete_source_branch,
         default_branch,
+        branch_prefix,
         **get_common_options(),
     )
     if web:

--- a/src/doing/pr/commands.py
+++ b/src/doing/pr/commands.py
@@ -120,7 +120,7 @@ def close(pr_id):
     required=False,
     default="",
     type=str,
-    help="The prefix to be prepended to the branch name. Defaults to \"\"",
+    help='The prefix to be prepended to the branch name. Defaults to ""',
     show_envvar=True,
 )
 def create(

--- a/src/doing/pr/create_pr.py
+++ b/src/doing/pr/create_pr.py
@@ -28,6 +28,7 @@ def cmd_create_pr(
     checkout: bool,
     delete_source_branch: bool,
     default_branch: str,
+    branch_prefix: str,
     team: str,
     area: str,
     iteration: str,
@@ -91,7 +92,7 @@ def cmd_create_pr(
     cmd = f'az repos ref list --repository "{repo_name}" --query "[?name==\'{default_branch}\'].objectId" '
     cmd += f'--org "{organization}" -p "{project}"'
     master_branch_object_id = run_command(cmd)[0]
-    branch_name = f"{work_item_id}_{to_snake_case(remove_special_chars(work_item_title))}"
+    branch_name = f"{branch_prefix}{work_item_id}_{to_snake_case(remove_special_chars(work_item_title))}"
     if branch_name in remote_branches:
         console.print(
             f"[dark_orange3]>[/dark_orange3] Remote branch '[cyan]{branch_name}[/cyan]' already exists, using that one"

--- a/src/doing/workon/commands.py
+++ b/src/doing/workon/commands.py
@@ -92,7 +92,7 @@ from doing.utils import get_config
     required=False,
     default="",
     type=str,
-    help="The prefix to be prepended to the branch name. Defaults to \"\"",
+    help='The prefix to be prepended to the branch name. Defaults to ""',
     show_envvar=True,
 )
 def workon(
@@ -107,7 +107,7 @@ def workon(
     delete_source_branch: bool,
     story_points,
     default_branch,
-    branch_prefix: str
+    branch_prefix: str,
 ):
     """
     Create issue with PR and switch git branch.

--- a/src/doing/workon/commands.py
+++ b/src/doing/workon/commands.py
@@ -87,6 +87,14 @@ from doing.utils import get_config
     help="The name of the branch to branch from and to. It overrides the repository's default branch.",
     show_envvar=True,
 )
+@click.option(
+    "--branch-prefix",
+    required=False,
+    default="",
+    type=str,
+    help="The prefix to be prepended to the branch name. Defaults to \"\"",
+    show_envvar=True,
+)
 def workon(
     issue,
     type,
@@ -99,6 +107,7 @@ def workon(
     delete_source_branch: bool,
     story_points,
     default_branch,
+    branch_prefix: str
 ):
     """
     Create issue with PR and switch git branch.
@@ -134,5 +143,6 @@ def workon(
         checkout=checkout,
         delete_source_branch=delete_source_branch,
         default_branch=default_branch,
+        branch_prefix=branch_prefix,
         **get_common_options(),
     )


### PR DESCRIPTION
Hello,
We like using branch prefixes like `feat/`, `chore/`, `fix/` or `release/` to benefit from ADO's foldered branch viewer and folder policies.
So I've added a new option to both `workon` and `create_pr` to optionally specify such a prefix to be used only for the branch name :)