### PR TITLE
Use Python 3.7 style typing

### DIFF
--- a/src/doing/issue/open_issue.py
+++ b/src/doing/issue/open_issue.py
@@ -1,11 +1,11 @@
-from typing import Union
+from __future__ import annotations
 
 import click
 
 from doing.utils import get_config
 
 
-def cmd_open_issue(work_item_id: Union[str, int]) -> None:
+def cmd_open_issue(work_item_id: str | int) -> None:
     """
     Open a specific WORK_ITEM_ID.
 

--- a/src/doing/list/_list.py
+++ b/src/doing/list/_list.py
@@ -1,6 +1,7 @@
+from __future__ import annotations
+
 import datetime
 from datetime import timezone
-from typing import Dict, List
 
 import timeago
 from rich.console import Console
@@ -133,7 +134,7 @@ def cmd_list(
         console.print(" ".join(wi_array))
         return
 
-    workitem_prs = {}  # type: Dict
+    workitem_prs: dict = {}
 
     # Now for each work item we could get linked PRs
     # However, APIs requests are slow, and most work items don't have a PR.
@@ -189,7 +190,7 @@ def cmd_list(
 
 
 def build_table(
-    work_items: List, workitem_prs: Dict, iteration: str, show_state: bool, last_build: bool = False
+    work_items: list, workitem_prs: dict, iteration: str, show_state: bool, last_build: bool = False
 ) -> Table:
     """Build rich table with open issues."""
     # Create our table

--- a/src/doing/pr/open_pr.py
+++ b/src/doing/pr/open_pr.py
@@ -1,11 +1,11 @@
-from typing import Union
+from __future__ import annotations
 
 import click
 
 from doing.utils import get_config, get_repo_name
 
 
-def cmd_open_pr(pullrequest_id: Union[str, int]) -> None:
+def cmd_open_pr(pullrequest_id: str | int) -> None:
     """
     Open a specific PULLREQUEST_ID. '!' prefix is allowed.
     """

--- a/src/doing/utils.py
+++ b/src/doing/utils.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import json
 import os
 import re
@@ -5,9 +7,10 @@ import string
 import subprocess
 import sys
 from collections import OrderedDict
+from collections.abc import Iterator
 from functools import lru_cache
 from platform import uname
-from typing import Any, Dict, Iterator
+from typing import Any
 
 import psutil
 import yaml
@@ -168,7 +171,7 @@ def get_config(key: str = "", fallback: Any = None, envvar_prefix: str = "DOING_
 
     # Load the config file
     with open(conf_path) as file:
-        conf: Dict[str, Any] = yaml.load(file, Loader=yaml.FullLoader)
+        conf: dict[str, Any] = yaml.load(file, Loader=yaml.FullLoader)
 
     # deprecations
     if key == "default_workitem_type":
@@ -200,7 +203,7 @@ def get_config(key: str = "", fallback: Any = None, envvar_prefix: str = "DOING_
         raise ConfigurationError(msg)
 
 
-def pprint(obj: Dict[Any, Any]) -> None:
+def pprint(obj: dict[Any, Any]) -> None:
     """
     Pretty print dictionaries.
     """


### PR DESCRIPTION
Since this project only support 3.7+ it makes sense to use a more modern style of typing.

It has the additional benefit of not requiring that many imports from `typing`.